### PR TITLE
Check for active hotspot before stopping

### DIFF
--- a/ap-hotspot
+++ b/ap-hotspot
@@ -226,6 +226,11 @@ fi
 stop() {
 # Check root
 check_root
+# Check if the hotspot is active
+if [[ -z $(ifconfig | grep "mon.$INTERFACE_WLAN") ]]; then
+	show_info "Wireless Hotspot is not active"
+	exit 1
+fi
 # Get variables
 get_vars
 # Kill process


### PR DESCRIPTION
Added a minor check for an existing hotspot before attempting to stop - This prevents the "ifconfig "mon.$INTERFACE_WLAN" down" line from throwing an error when there is no active hotspot.
