### PR TITLE
Change the way displaying interfaces of net and make it more readable

### DIFF
--- a/ap-hotspot
+++ b/ap-hotspot
@@ -107,7 +107,7 @@ rm -f "$hotspotconfig"
 rm -f "$dnsmasqconfig"
 # Detect configuration
 show_msg "Detecting configuration..."
-INTERFACE_NET=$(route | grep -iw "default" | awk '{print $NF}')
+INTERFACE_NET=$(route | grep -iw "default" | awk '{printf "%s ", $NF}')
 INTERFACE_WLAN=$(iwconfig 2>&1 | grep "^wlan" | sed -e 's/ .*//g' | tail -n 1)
 SSID="myhotspot"
 WPAPASS="qwerty0987"


### PR DESCRIPTION
Fix showing interfaces of net problem when running configure cmd in a computer where more than one interfaces exist.
