### PR TITLE
Added automatic disconnect from WiFi and fixed hos

### DIFF
--- a/ap-hotspot
+++ b/ap-hotspot
@@ -76,8 +76,9 @@ if [[ $(iwconfig "$INTERFACE_WLAN" 2>&1 | grep "Tx-Power=off") ]]; then
 	exit 1
 # Check if Wireless is enabled, but connected to a network
 elif [[ ! $(iwconfig "$INTERFACE_WLAN" 2>&1 | grep "ESSID:off/any") && $(iwconfig "$INTERFACE_WLAN" 2>&1 | grep "ESSID:") ]]; then
-	show_err "Please disconnect WiFi before proceeding"
-	exit 1
+	show_err "Disconnecting from WiFi before proceeding"
+	ifconfig "$INTERFACE_WLAN" down
+	ifconfig "$INTERFACE_WLAN" up
 fi
 }
 
@@ -180,8 +181,9 @@ INTERFACE_NET=$(grep "INTERFACE_NET" "$dnsmasqconfig" | sed -e 's/#INTERFACE_NET
 start() {
 # Check previous process
 if [[ -f "$pidfile" ]]; then
-	show_err "Another process is already running"
-	exit 1
+	show_err "Another process is already running..." 2>&1 | show_debug
+	show_err "Stopping that by removing the pidfile." 2>&1 | show_debug
+	rm /tmp/hotspot.pid 2>&1 | show_debug
 fi
 # Check root
 check_root


### PR DESCRIPTION
Now, instead of asking user to disconnect from wifi, ifconfig down and up is done to fix it
Also, Abrupt stop of hotspot leaves and orphan pidfile which causes "Another process already running " error.
Added command to remove the /tmp/hotspot.pid file and continue starting the hotspot